### PR TITLE
Add support related in BGP-LS SRv6 Architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ artifacts
 requirements.txt
 
 .codegpt
+
+# spot
+bgpls-receiver.log

--- a/decode_bgpls.py
+++ b/decode_bgpls.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+# ExaBGPのソースディレクトリをパスに追加
+sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
+
+from exabgp.bgp.message.update.nlri.bgpls.nlri import BGPLS
+from exabgp.bgp.message.update.nlri.bgpls.link import LINK
+from exabgp.bgp.message.update.nlri.bgpls.node import NODE
+from exabgp.protocol.family import AFI, SAFI
+from exabgp.bgp.message import Action
+import json
+
+def decode_bgpls_hex(hex_str):
+    try:
+        # 16進数文字列をバイトデータに変換
+        data = bytes.fromhex(hex_str)
+        
+        # BGP-LSメッセージをデコード
+        nlri, rest = BGPLS.unpack_nlri(AFI.bgpls, SAFI.bgp_ls, data, Action.ANNOUNCE, None)
+        
+        # 結果を表示
+        print("\nDecoded BGP-LS Message:")
+        print(f"Type: {nlri.NAME}")
+        print(f"Protocol ID: {nlri.proto_id}")
+        print(f"Domain: {nlri.domain}")
+        
+        # JSON形式で整形して表示
+        print("\nFormatted JSON:")
+        json_data = json.loads(nlri.json())
+        print(json.dumps(json_data, indent=2))
+        
+        return nlri
+    
+    except Exception as e:
+        print(f"Error decoding message: {str(e)}")
+        return None
+
+if __name__ == "__main__":
+    # サンプルのBGP-LSメッセージ
+    sample_hex = "0002FFFF03000000000000000001000020020000040000000102010004C0A87A7E0202000400000000020300040A0A0A0A01010020020000040000000102010004C0A87A7E0202000400000000020300040A020202"
+    
+    print("Decoding sample BGP-LS message...")
+    decode_bgpls_hex(sample_hex)

--- a/etc/exabgp/conf-srv6-bgpls-receiver.conf
+++ b/etc/exabgp/conf-srv6-bgpls-receiver.conf
@@ -1,0 +1,28 @@
+process watch-routes {
+    run ../../watch.py;
+    encoder json;
+}
+
+neighbor 127.0.0.1 {
+    router-id 10.0.0.2;
+    local-address 127.0.0.1;
+    local-as 65002;
+    peer-as 65001;
+    connect 1179;
+
+    api {
+        processes [ watch-routes ];
+        receive {
+            parsed;
+            update;
+        }
+    }
+
+    family {
+        bgp-ls bgp-ls;
+    }
+
+    capability {
+        add-path send/receive;
+    }
+}

--- a/etc/exabgp/conf-srv6-bgpls-sender.conf
+++ b/etc/exabgp/conf-srv6-bgpls-sender.conf
@@ -1,0 +1,24 @@
+neighbor 127.0.0.1 {
+    router-id 10.0.0.1;
+	local-address 127.0.0.1;
+    local-as 65001;
+    peer-as 65002;
+    listen 1179;
+    
+    family {
+        bgp-ls bgp-ls;
+    }
+
+    announce {
+        bgp-ls {
+            bgp-ls \
+            protocol-id 5 \
+            identifier 1 \
+            local-node-descriptor ( 65000 1 0 127.0.0.1 ) \
+            srv6-sid-information [ 2001:db8:85a3::8a2e:370:7335 2001:db8:85a3::8a2e:370:7336 ] \
+            multi-topologies [ ( 1 2 3 ) ( 4 5 ) ] \
+            service-chainings [ ( 1 0 0 0 ) ( 2 0 0 0 ) ] \
+            opaque-metadata [ ( 8 1 0 first ) ( 9 2 0 second ) ];
+        }
+    }
+}

--- a/etc/exabgp/exabgp.env
+++ b/etc/exabgp/exabgp.env
@@ -1,0 +1,61 @@
+
+[exabgp.api]
+ack = true
+chunk = 1
+cli = true
+compact = false
+encoder = json
+pipename = 'exabgp'
+respawn = true
+terminate = false
+
+[exabgp.bgp]
+openwait = 60
+passive = false
+
+[exabgp.cache]
+attributes = true
+nexthops = true
+
+[exabgp.daemon]
+daemonize = false
+drop = true
+pid = ''
+umask = '0o137'
+user = 'nobody'
+
+[exabgp.log]
+all = false
+configuration = true
+daemon = true
+destination = 'stdout'
+enable = true
+level = INFO
+message = false
+network = true
+packets = false
+parser = false
+processes = true
+reactor = true
+rib = false
+routes = false
+short = true
+statistics = true
+timers = false
+
+[exabgp.pdb]
+enable = false
+
+[exabgp.profile]
+enable = false
+file = ''
+
+[exabgp.reactor]
+speed = 1.0
+
+[exabgp.tcp]
+acl = false
+bind = ''
+delay = 0
+once = false
+port = 179

--- a/src/exabgp/bgp/message/update/__init__.py
+++ b/src/exabgp/bgp/message/update/__init__.py
@@ -27,6 +27,7 @@ from exabgp.bgp.message.update.attribute import MPURNLRI
 
 from exabgp.bgp.message.notification import Notify
 from exabgp.bgp.message.update.nlri import NLRI
+from exabgp.bgp.message.update.nlri.bgpls.srv6sid import SRv6SID
 
 from exabgp.logger import log
 from exabgp.logger import logfunc
@@ -127,6 +128,10 @@ class Update(Message):
 
             if add_v4:
                 nlris.append(nlri)
+                continue
+
+            if isinstance(nlri, SRv6SID):
+                mp_nlris.setdefault(nlri.family().afi_safi(), {}).setdefault(nlri.action, []).append(nlri)
                 continue
 
             if nlri.nexthop.afi != AFI.undefined:

--- a/src/exabgp/bgp/message/update/nlri/bgpls/nlri.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/nlri.py
@@ -50,6 +50,7 @@ from exabgp.bgp.message.update.nlri.qualifier import RouteDistinguisher
 #                   |  2   | Link NLRI                 |
 #                   |  3   | IPv4 Topology Prefix NLRI |
 #                   |  4   | IPv6 Topology Prefix NLRI |
+#                   |  6   | SRv6 SID NLRI             |
 #                   +------+---------------------------+
 # ==================================================================== BGP LINK_STATE
 #            +-------------+----------------------------------+
@@ -90,9 +91,12 @@ class BGPLS(NLRI):
         self._packed = b''
 
     def pack_nlri(self, negotiated=None):
-        return pack('!BB', self.CODE, len(self._packed)) + self._packed
+        packet = pack('!HH', self.CODE, len(self._packed)) + self._packed
+        print("✅ SRv6 SID NLRI: ", packet.hex())
+        return packet
 
     def __len__(self):
+        self._pack()
         return len(self._packed) + 2
 
     def __hash__(self):
@@ -113,6 +117,7 @@ class BGPLS(NLRI):
 
     @classmethod
     def unpack_nlri(cls, afi, safi, bgp, action, addpath):
+        print("✅ SRv6 SID NLRI: ", bgp.hex())
         code, length = unpack('!HH', bgp[:4])
         if code in cls.registered_bgpls:
             if safi == SAFI.bgp_ls_vpn:

--- a/src/exabgp/bgp/message/update/nlri/bgpls/srv6sid.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/srv6sid.py
@@ -1,0 +1,192 @@
+from struct import pack, unpack
+from exabgp.bgp.message.update.nlri.bgpls import BGPLS
+from exabgp.bgp.message import Action
+from exabgp.protocol.ip import IP, IPv6
+from exabgp.bgp.message.update.nlri.bgpls.tlvs.multitopology import MultiTopology
+from exabgp.bgp.message.update.nlri.bgpls.tlvs.servicechaining import ServiceChaining
+from exabgp.bgp.message.update.nlri.bgpls.tlvs.opaquemetadata import OpaqueMetadata
+from exabgp.protocol.ip import NoNextHop
+
+# https://www.rfc-editor.org/rfc/rfc9514.html#name-srv6-sid-nlri
+@BGPLS.register
+class SRv6SID(BGPLS):
+    CODE = 6
+    NAME = 'bgpls-srv6-sid'
+    SHORT_NAME = 'SRV6_SID'
+
+    def __init__(
+            self,
+            protocol_id,
+            identifier,
+            local_node_descriptor,
+            srv6_sid_information=[],
+            multi_topologies=[],
+            service_chainings=[],
+            opaque_metadata=[],
+            packed=None
+        ):
+        BGPLS.__init__(self, action=Action.ANNOUNCE, addpath=None)
+        self.protocol_id = protocol_id
+        self.identifier = identifier
+        self.local_node_descriptor = local_node_descriptor
+        self.srv6_sid_information = srv6_sid_information
+        self.multi_topologies = multi_topologies
+        self.service_chainings = service_chainings
+        self.opaque_metadata = opaque_metadata
+        # self.nexthop = NoNextHop
+        self.nexthop = IPv6('::1')
+        self._packed = packed
+
+    def _pack(self, packed=None):
+        if self._packed:
+            return self._packed
+
+        if packed:
+            self._packed = packed
+            return packed
+
+        self._packed = (
+            pack('!B', self.protocol_id) +
+            pack('!Q', self.identifier) +
+            self.local_node_descriptor.pack() +
+            b''.join(map(lambda x: x.pack(), self.srv6_sid_information)) +
+            b''.join(map(lambda x: x.pack(), self.multi_topologies)) +
+            b''.join(map(lambda x: x.pack(), self.service_chainings)) +
+            b''.join(map(lambda x: x.pack(), self.opaque_metadata))
+        )
+        return self._packed
+
+    @classmethod
+    def unpack_nlri(cls, data, rd):
+        protocol_id = unpack('!B', data[:1])[0]
+        identifier = unpack('!Q', data[1:9])[0]
+        local_node_descriptor = LocalNodeDescriptor.unpack(data[9:])
+        multi_topologies = []
+        srv6_sid_information = []
+        service_chainings = []
+        opaque_metadata = []
+        tlvs = data[9+16:]
+
+        while tlvs:
+            tlv_type, tlv_length = unpack('!HH', tlvs[:4])
+            value = tlvs[4 : 4 + tlv_length]
+            tlvs = tlvs[4 + tlv_length :]
+
+            if tlv_type == 263:
+                multi_topologies.append(MultiTopology.unpack(value))
+                continue
+
+            if tlv_type == 518:
+                srv6_sid_information.append(SRv6SIDDescriptor.unpack(value))
+                continue
+
+            if tlv_type == 65000:
+                service_chainings.append(ServiceChaining.unpack(value))
+                continue
+
+            if tlv_type == 65001:
+                opaque_metadata.append(OpaqueMetadata.unpack(tlv_length, value))
+                continue
+
+        return cls(
+            protocol_id=protocol_id,
+            identifier=identifier,
+            local_node_descriptor=local_node_descriptor,
+            srv6_sid_information=srv6_sid_information,
+            multi_topologies=multi_topologies,
+            service_chainings=service_chainings,
+            opaque_metadata=opaque_metadata
+        )
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, SRv6SID)
+            and self.protocol_id == other.protocol_id
+            and self.identifier == other.identifier
+            and self.local_node_descriptor == other.local_node_descriptor
+            and self.srv6_sid_information == other.srv6_sid_information
+            and self.multi_topologies == other.multi_topologies
+            and self.service_chainings == other.service_chainings
+            and self.opaque_metadata == other.opaque_metadata
+        )
+
+    def __str__(self):
+        return (
+            f"SRv6SID(protocol_id={self.protocol_id}, identifier={self.identifier}, "
+            f"local_node_descriptor={self.local_node_descriptor}, srv6_sid_information={self.srv6_sid_information}, "
+            f"multi_topologies={self.multi_topologies}, service_chainings={self.service_chainings}, "
+            f"opaque_metadata={self.opaque_metadata})"
+        )
+    
+    def json(self, compact=None):
+        srv6_sid_information = ', '.join(d.json() for d in self.srv6_sid_information)
+        content = ', '.join(
+            [
+                '"protocol-id": %d' % int(self.protocol_id),
+                '"identifier": %d' % int(self.identifier),
+                '"local-node-descriptor": { %s }' % self.local_node_descriptor.json(),
+                '"srv6-sid-information": [ %s ]' % srv6_sid_information,
+            ]
+        )
+        if self.multi_topologies:
+            content += ', "multi-topologies": [ %s ]' % ', '.join(mt.json() for mt in self.multi_topologies)
+        if self.service_chainings:
+            content += ', "service-chainings": [ %s ]' % ', '.join(sc.json() for sc in self.service_chainings)
+        if self.opaque_metadata:
+            content += ', "opaque-metadata": [ %s ]' % ', '.join(om.json() for om in self.opaque_metadata)
+
+        return '{ %s }' % (content)
+
+# TODO: NodeDescriptorを使えるか確認
+class LocalNodeDescriptor:
+    def __init__(self, as_number, bgp_ls_identifier, ospf_area_id, router_id):
+        self.as_number = int(as_number)
+        self.bgp_ls_identifier = int(bgp_ls_identifier)
+        self.ospf_area_id = int(ospf_area_id)
+        self.router_id = router_id
+
+    def pack(self):
+        return (
+            pack('!I', self.as_number) +
+            pack('!I', self.bgp_ls_identifier) +
+            pack('!I', self.ospf_area_id) +
+            IP.pton(self.router_id)
+        )
+
+    @staticmethod
+    def unpack(data):
+        as_number = unpack('!I', data[:4])[0]
+        bgp_ls_identifier = unpack('!I', data[4:8])[0]
+        ospf_area_id = unpack('!I', data[8:12])[0]
+        router_id = IP.ntop(data[12:16])
+        return LocalNodeDescriptor(as_number, bgp_ls_identifier, ospf_area_id, router_id)
+    
+    def json(self, compact=None):
+        return ', '.join([
+            '"as-number": %d' % self.as_number,
+            '"bgp-ls-identifier": %d' % self.bgp_ls_identifier,
+            '"ospf-area-id": %d' % self.ospf_area_id,
+            '"router-id": "%s"' % self.router_id
+        ])
+
+
+class SRv6SIDDescriptor:
+    def __init__(self, sid):
+        self.type = 518
+        self.length = 16
+        self.sid = sid
+
+    def pack(self):
+        return pack('!HH', self.type, self.length) + IPv6.pton(self.sid)
+
+    @staticmethod
+    def unpack(data):
+        return SRv6SIDDescriptor(IPv6.ntop(data))
+    
+    def json(self, compact=None):
+        content = ', '.join([
+            '"type": %d' % self.type,
+            '"length": %d' % self.length,
+            '"sid": "%s"' % self.sid
+        ])
+        return '{ %s }' % (content)

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/multitopology.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/multitopology.py
@@ -102,3 +102,29 @@ class MTID(object):
         if self._packed:
             return self._packed
         raise RuntimeError('Not implemented')
+
+class MultiTopology(object):
+    def __init__(self, mt_ids):
+        self.type = 263
+        self.length = len(mt_ids) * 2
+        self.mt_ids = mt_ids
+
+    def pack(self):
+        return struct.pack('!HH', self.type, self.length) + b''.join(struct.pack('!H', mt_id) for mt_id in self.mt_ids)
+
+    @classmethod
+    def unpack(cls, data):
+        mt_ids = []
+        while data:
+            mt_id = struct.unpack('!H', data[:2])[0]
+            mt_ids.append(mt_id)
+            data = data[2:]
+        return MultiTopology(mt_ids)
+
+    def json(self, compact=None):
+        content = ', '.join([
+            '"type": %d' % self.type,
+            '"length": %d' % self.length,
+            '"mt_ids": [ %s ]' % ', '.join(str(mt_id) for mt_id in self.mt_ids)
+        ])
+        return '{ %s }' % (content)

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/opaquemetadata.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/opaquemetadata.py
@@ -1,0 +1,28 @@
+from struct import pack, unpack
+
+class OpaqueMetadata(object):
+    def __init__(self, length, opaque_type, flags, value):
+        self.type = 65001
+        self.length = int(length)
+        self.opaque_type = int(opaque_type)
+        self.flags = int(flags)
+        self.value = str(value).encode('utf-8')
+
+    def pack(self):
+        return pack('!HHHB', self.type, self.length, self.opaque_type, self.flags) + self.value
+
+    @staticmethod
+    def unpack(length, data):
+        opaque_type, flags = unpack('!HB', data[:3])
+        value = data[3:].decode('utf-8')
+        return OpaqueMetadata(length, opaque_type, flags, value)
+
+    def json(self, compact=None):
+        content = ', '.join([
+            '"type": %d' % self.type,
+            '"length": %d' % self.length,
+            '"opaque-type": %d' % self.opaque_type,
+            '"flags": %d' % self.flags,
+            '"value": "%s"' % self.value.decode('utf-8')
+        ])
+        return '{ %s }' % (content)

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/servicechaining.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/servicechaining.py
@@ -1,0 +1,29 @@
+from struct import pack, unpack
+
+class ServiceChaining(object):
+    def __init__(self, service_type, flags, traffic_type, reserved):
+        self.type = 65000
+        self.length = 6
+        self.service_type = int(service_type)
+        self.flags = int(flags)
+        self.traffic_type = int(traffic_type)
+        self.reserved = int(reserved)
+
+    def pack(self):
+        return pack('!HHHBBH', self.type, self.length, self.service_type, self.flags, self.traffic_type, self.reserved)
+
+    @staticmethod
+    def unpack(data):
+        service_type, flags, traffic_type, reserved = unpack('!HBBH', data)
+        return ServiceChaining(service_type, flags, traffic_type, reserved)
+
+    def json(self, compact=None):
+        content = ', '.join([
+            '"type": %d' % self.type,
+            '"length": %d' % self.length,
+            '"service-type": %d' % self.service_type,
+            '"flags": %d' % self.flags,
+            '"traffic-type": %d' % self.traffic_type,
+            '"reserved": %d' % self.reserved
+        ])
+        return '{ %s }' % (content)

--- a/src/exabgp/configuration/announce/__init__.py
+++ b/src/exabgp/configuration/announce/__init__.py
@@ -139,3 +139,10 @@ class AnnounceL2VPN(ParseAnnounce):
 
     def clear(self):
         return True
+
+class AnnounceBGPLSAFI(ParseAnnounce):
+    name = 'bgp-ls'
+    afi = AFI.bgpls
+
+    def clear(self):
+        return True

--- a/src/exabgp/configuration/announce/bgpls.py
+++ b/src/exabgp/configuration/announce/bgpls.py
@@ -1,0 +1,114 @@
+# encoding: utf-8
+"""
+announce/vpn.py
+
+Created by Thomas Mangin on 2017-07-09.
+Copyright (c) 2009-2017 Exa Networks. All rights reserved.
+License: 3-clause BSD. (See the COPYRIGHT file)
+"""
+
+from exabgp.rib.change import Change
+
+from exabgp.protocol.family import AFI
+from exabgp.protocol.family import SAFI
+
+from exabgp.bgp.message.update.attribute import Attributes
+
+from exabgp.configuration.announce import ParseAnnounce
+
+from exabgp.configuration.bgpls.parser import protocol_id
+from exabgp.configuration.bgpls.parser import identifier
+from exabgp.configuration.bgpls.parser import local_node_descriptor
+from exabgp.configuration.bgpls.parser import srv6_sid_information
+from exabgp.configuration.bgpls.parser import multi_topologies
+from exabgp.configuration.bgpls.parser import service_chainings
+from exabgp.configuration.bgpls.parser import opaque_metadata
+from exabgp.bgp.message.update.nlri.bgpls.srv6sid import SRv6SID
+
+
+class AnnounceBGPLSSAFI(ParseAnnounce):
+    definition = [
+        'protocol-id <protocol id; 8 bits number>',
+        'identifier <identifier; 64 bits number>',
+        'local-node-descriptor ( <asn> <bgp ls identifier; 32 bits number> <ospf area id; 32 bits number> <ip> )',
+        'srv6-sid-information [ <ipv6>.. ]',
+        'multi-topologies [ ( <mt id; 16 bits number>.. ).. ]',
+        'service-chainings [ ( <service type; 16 bits number> <flags; 8 bits number> <traffic type; 8 bits number> <reserved; 16 bits number> ).. ]',
+        'opaque-metadata [ ( <length; 16 bits number> <opaque type; 16 bits number> <flags; 8 bits number> <value; string> ).. ]',
+    ]
+
+    syntax = 'bgp-ls %s\n' % '  '.join(definition)
+
+    known = {
+        'protocol-id': protocol_id,
+        'identifier': identifier,
+        'local-node-descriptor': local_node_descriptor,
+        'srv6-sid-information': srv6_sid_information,
+        'multi-topologies': multi_topologies,
+        'service-chainings': service_chainings,
+        'opaque-metadata': opaque_metadata,
+    }
+
+    action = {
+        'protocol-id': 'nlri-set',
+        'identifier': 'nlri-set',
+        'local-node-descriptor': 'nlri-set',
+        'srv6-sid-information': 'nlri-set',
+        'multi-topologies': 'nlri-set',
+        'service-chainings': 'nlri-set',
+        'opaque-metadata': 'nlri-set',
+    }
+
+    assign = {
+        'protocol-id': 'protocol_id',
+        'identifier': 'identifier',
+        'local-node-descriptor': 'local_node_descriptor',
+        'srv6-sid-information': 'srv6_sid_information',
+        'multi-topologies': 'multi_topologies',
+        'service-chainings': 'service_chainings',
+        'opaque-metadata': 'opaque_metadata',
+    }
+
+    name = 'bgp-ls'
+    afi = None
+
+    def __init__(self, tokeniser, scope, error):
+        ParseAnnounce.__init__(self, tokeniser, scope, error)
+
+    def clear(self):
+        return True
+
+    def post(self):
+        return self._check()
+
+    @staticmethod
+    def check(change, afi):
+        return True
+
+
+def bgpls(tokeniser, afi, safi):
+    change = Change(SRv6SID(None, None, None), Attributes())
+
+    while True:
+        command = tokeniser()
+        if not command:
+            break
+
+        action = AnnounceBGPLSSAFI.action[command]
+        if 'nlri-set' in action:
+            change.nlri.assign(AnnounceBGPLSSAFI.assign[command], AnnounceBGPLSSAFI.known[command](tokeniser))
+        elif 'attribute-add' in action:
+            change.attributes.add(AnnounceBGPLSSAFI.known[command](tokeniser))
+        else:
+            raise ValueError('bgp-ls: unknown command "%s"' % command)
+
+    change.nlri._pack()
+    change.nlri.pack()
+    return [
+        change,
+    ]
+
+
+@ParseAnnounce.register('bgp-ls', 'extend-name', 'bgp-ls')
+def bgpls_bgpls(tokeniser):
+    return bgpls(tokeniser, AFI.bgpls, SAFI.bgp_ls)

--- a/src/exabgp/configuration/bgpls/parser.py
+++ b/src/exabgp/configuration/bgpls/parser.py
@@ -1,0 +1,101 @@
+# encoding: utf-8
+from exabgp.protocol.family import AFI
+
+from exabgp.protocol.ip import IP
+from exabgp.bgp.message.update.attribute import NextHopSelf
+
+from exabgp.bgp.message.update.nlri import VPLS
+from exabgp.bgp.message.update.attribute import Attributes
+from exabgp.rib.change import Change
+from exabgp.bgp.message.update.nlri.bgpls.srv6sid import LocalNodeDescriptor, SRv6SIDDescriptor, MultiTopology, ServiceChaining, OpaqueMetadata
+
+
+def protocol_id(tokeniser):
+    return int(tokeniser())
+
+def identifier(tokeniser):
+    return int(tokeniser())
+
+def local_node_descriptor(tokeniser):
+    value = tokeniser()
+    if value == '(':
+        as_number = tokeniser()
+        bgp_ls_identifier = tokeniser()
+        ospf_area_id = tokeniser()
+        router_id = tokeniser()
+        tokeniser()
+        return LocalNodeDescriptor(as_number, bgp_ls_identifier, ospf_area_id, router_id)
+    else:
+        raise ValueError('invalid local node descriptor')
+
+def srv6_sid_information(tokeniser):
+    srv6_sid_info = []
+
+    value = tokeniser()
+    if value == '[':
+        while True:
+            value = tokeniser()
+            if value == ']':
+                break
+            srv6_sid_info.append(SRv6SIDDescriptor(value))
+    else:
+        srv6_sid_info.append(SRv6SIDDescriptor(value))
+
+    return srv6_sid_info
+
+def multi_topologies(tokeniser):
+    mt_ids = []
+    
+    value = tokeniser()
+    if value == '[':
+        while True:
+            value = tokeniser()
+            if value == '(':
+                ids = []
+                while True:
+                    value = tokeniser()
+                    if value == ')':
+                        break
+                    ids.append(int(value))
+                mt_ids.append(MultiTopology(ids))
+            elif value == ']':
+                break
+    else:
+        mt_ids.append(MultiTopology([int(value)]))
+    return mt_ids
+
+def service_chainings(tokeniser):
+    service_chainings = []
+    
+    value = tokeniser()
+    if value == '[':
+        while True:
+            value = tokeniser()
+            if value == '(':
+                service_type = tokeniser()
+                flags = tokeniser()
+                traffic_type = tokeniser()
+                reserved = tokeniser()
+                tokeniser()
+                service_chainings.append(ServiceChaining(service_type, flags, traffic_type, reserved))
+            elif value == ']':
+                break
+    return service_chainings
+
+def opaque_metadata(tokeniser):
+    opaque_metadata = []
+    
+    value = tokeniser()
+    if value == '[':
+        while True:
+            value = tokeniser()
+            if value == '(':
+                length = tokeniser()
+                opaque_type = tokeniser()
+                flags = tokeniser()
+                metadata = tokeniser()
+                tokeniser()
+                opaque_metadata.append(OpaqueMetadata(length, opaque_type, flags, metadata))
+            elif value == ']':
+                break
+    return opaque_metadata

--- a/src/exabgp/configuration/configuration.py
+++ b/src/exabgp/configuration/configuration.py
@@ -32,6 +32,7 @@ from exabgp.configuration.announce import SectionAnnounce
 from exabgp.configuration.announce import AnnounceIPv4
 from exabgp.configuration.announce import AnnounceIPv6
 from exabgp.configuration.announce import AnnounceL2VPN
+from exabgp.configuration.announce import AnnounceBGPLSAFI
 from exabgp.configuration.static import ParseStatic
 from exabgp.configuration.static import ParseStaticRoute
 from exabgp.configuration.flow import ParseFlow
@@ -54,6 +55,7 @@ from exabgp.configuration.announce.mvpn import AnnounceMVPN  # noqa: F401,E261,E
 from exabgp.configuration.announce.flow import AnnounceFlow  # noqa: F401,E261,E501
 from exabgp.configuration.announce.vpls import AnnounceVPLS  # noqa: F401,E261,E501
 from exabgp.configuration.announce.mup import AnnounceMup  # noqa: F401,E261,E501
+from exabgp.configuration.announce.bgpls import AnnounceBGPLSSAFI  # noqa: F401,E261,E501
 
 
 class _Configuration(object):
@@ -143,6 +145,7 @@ class Configuration(_Configuration):
         self.announce_ipv4 = AnnounceIPv4(*params)
         self.announce_ipv6 = AnnounceIPv6(*params)
         self.announce_l2vpn = AnnounceL2VPN(*params)
+        self.announce_bgpls_afi = AnnounceBGPLSAFI(*params)
         self.flow = ParseFlow(*params)
         self.flow_route = ParseFlowRoute(*params)
         self.flow_match = ParseFlowMatch(*params)
@@ -253,6 +256,7 @@ class Configuration(_Configuration):
                     'ipv4': self.announce_ipv4.name,
                     'ipv6': self.announce_ipv6.name,
                     'l2vpn': self.announce_l2vpn.name,
+                    'bgp-ls': self.announce_bgpls_afi.name,
                 },
             },
             self.announce_ipv4.name: {
@@ -269,6 +273,13 @@ class Configuration(_Configuration):
                 'class': self.announce_l2vpn,
                 'commands': [
                     'vpls',
+                ],
+                'sections': {},
+            },
+            self.announce_bgpls_afi.name: {
+                'class': self.announce_bgpls_afi,
+                'commands': [
+                    'bgp-ls',
                 ],
                 'sections': {},
             },
@@ -357,6 +368,7 @@ class Configuration(_Configuration):
         self.announce_ipv6.clear()
         self.announce_ipv4.clear()
         self.announce_l2vpn.clear()
+        self.announce_bgpls_afi.clear()
         self.announce.clear()
         self.static.clear()
         self.static_route.clear()

--- a/test_srv6.py
+++ b/test_srv6.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+# ExaBGPのソースディレクトリをパスに追加
+sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
+
+from exabgp.bgp.message.update.nlri.bgpls.srv6sid import SRv6SID
+from exabgp.bgp.message.update.attribute.sr.srv6.sidinformation import Srv6SidInformation
+from exabgp.bgp.message.update.attribute.sr.srv6.sidstructure import Srv6SidStructure
+from exabgp.bgp.message.update.nlri.bgpls.srv6sid import LocalNodeDescriptor, SRv6SIDDescriptor
+from exabgp.protocol.ip import IPv6
+from exabgp.bgp.message.update.nlri.bgpls.tlvs.multitopology import MultiTopology
+from exabgp.bgp.message.update.nlri.bgpls.tlvs.servicechaining import ServiceChaining
+from exabgp.bgp.message.update.nlri.bgpls.tlvs.opaquemetadata import OpaqueMetadata
+
+# https://www.rfc-editor.org/rfc/rfc9514.html#name-srv6-sid-nlri
+def encode_srv6_sid_nlri():
+    protocol_id = 5 # https://www.iana.org/assignments/bgp-ls-parameters/bgp-ls-parameters.xhtml#protocol-ids
+    identifier = 0x0000000000000001
+    local_node_descriptor = LocalNodeDescriptor(
+        as_number=65000,
+        bgp_ls_identifier=1,
+        ospf_area_id=0,
+        router_id='127.0.0.1'
+    )
+    srv6_sid_information = [
+        SRv6SIDDescriptor(sid='2001:db8:85a3::8a2e:370:7335'),
+        SRv6SIDDescriptor(sid='2001:db8:85a3::8a2e:370:7336')
+    ]
+    multi_topologies = [
+        MultiTopology(
+            mt_ids=[1, 2, 3]
+        ),
+        MultiTopology(
+            mt_ids=[4, 5]
+        )
+    ]
+    service_chainings = [
+        ServiceChaining(
+            service_type=1,
+            flags=0,
+            traffic_type=0,
+            reserved=0
+        ),
+        ServiceChaining(
+            service_type=2,
+            flags=0,
+            traffic_type=0,
+            reserved=0
+        )
+    ]
+    opaque_metadata = [
+        OpaqueMetadata(
+            length=8,
+            opaque_type=1,
+            flags=0,
+            value='first'
+        ),
+        OpaqueMetadata(
+            length=9,
+            opaque_type=2,
+            flags=0,
+            value='second'
+        )
+    ]
+    srv6_sid_nlri = SRv6SID(
+        protocol_id,
+        identifier,
+        local_node_descriptor,
+        srv6_sid_information,
+        multi_topologies=multi_topologies,
+        service_chainings=service_chainings,
+        opaque_metadata=opaque_metadata
+    )
+    packed_nlri = srv6_sid_nlri._pack()
+    print("Packed SRv6 SID NLRI:", packed_nlri)
+    return packed_nlri
+
+def decode_srv6_sid_nlri(packed_nlri):
+    try:
+        unpacked_nlri = SRv6SID.unpack_nlri(packed_nlri, None)
+        print("Decoded SRv6 SID NLRI:")
+        
+        print(f"Protocol ID: {unpacked_nlri.protocol_id}")
+        print(f"Identifier: {unpacked_nlri.identifier}")
+        print("Local Node Descriptor:")
+        print(f"  AS Number: {unpacked_nlri.local_node_descriptor.as_number}")
+        print(f"  BGP-LS Identifier: {unpacked_nlri.local_node_descriptor.bgp_ls_identifier}")
+        print(f"  OSPF Area ID: {unpacked_nlri.local_node_descriptor.ospf_area_id}")
+        print(f"  Router ID: {unpacked_nlri.local_node_descriptor.router_id}")
+        print("SRv6 SID Information:")
+        for srv6_sid_information in unpacked_nlri.srv6_sid_information:
+            print(f"  SID: {srv6_sid_information.sid}")
+        print("Multi Topologies:")
+        for multi_topology in unpacked_nlri.multi_topologies:
+            print(f"  Type: {multi_topology.type}")
+            print(f"  Length: {multi_topology.length}")
+            print(f"  Multi Topology IDs: {multi_topology.mt_ids}")
+        print("Service Chainings:")
+        for service_chaining in unpacked_nlri.service_chainings:
+            print(f"  Type: {service_chaining.type}")
+            print(f"  Length: {service_chaining.length}")
+            print(f"  Service Type: {service_chaining.service_type}")
+            print(f"  Flags: {service_chaining.flags}")
+            print(f"  Traffic Type: {service_chaining.traffic_type}")
+            print(f"  Reserved: {service_chaining.reserved}")
+        print("Opaque Metadata:")
+        for opaque_metadata in unpacked_nlri.opaque_metadata:
+            print(f"  Type: {opaque_metadata.type}")
+            print(f"  Length: {opaque_metadata.length}")
+            print(f"  Opaque Type: {opaque_metadata.opaque_type}")
+            print(f"  Flags: {opaque_metadata.flags}")
+            print(f"  Value: {opaque_metadata.value}")
+        
+        return unpacked_nlri
+    except Exception as e:
+        print(f"Error decoding SRv6 SID NLRI: {str(e)}")
+        return None
+
+if __name__ == "__main__":
+    print("--- encode_srv6_sid_nlri ---")
+    packed_nlri = encode_srv6_sid_nlri()
+    print("--- decode_srv6_sid_nlri ---")
+    decode_srv6_sid_nlri(packed_nlri)

--- a/watch.py
+++ b/watch.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+from time import strftime
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.absolute()
+LOG_FILE = f'{SCRIPT_DIR}/bgpls-receiver.log'
+
+while True:
+    try:
+        line = sys.stdin.readline().strip()
+        if not line:
+            continue
+            
+        message = json.loads(line)
+        log_message = f"{strftime('%H:%M:%S')} {json.dumps(message, indent=2)}\n"
+        
+        with open(LOG_FILE, 'a') as f:
+            f.write(log_message)
+        
+    except Exception as e:
+        with open(LOG_FILE, 'a') as f:
+            f.write(f"Error: {str(e)}\n")


### PR DESCRIPTION
SRv6 SFC Architecture with SR-aware Functionsに必要なSRv6向けBGP-LS拡張を実装
- RFC9514(SRv6向けのBGP-LS拡張)
  - SRv6 SID NLRI, SRv6 SID Information TLV
- RFC9552(BGPを用いたLSとTEの配布)
  - Local Node Descriptors, Multi-Topology Identifier
- draft-ietf-idr-bgp-ls-sr-service-segments(Segment Routing Service SegmentsのBGP-LS広告)
  - Service Chaining TLV, Opaque Metadata TLV

## 参考
- https://datatracker.ietf.org/meeting/121/materials/slides-121-hackathon-sessd-bgp-ls-extensions-for-srv6-service-chaining-00
- https://datatracker.ietf.org/doc/draft-watal-spring-srv6-sfc-sr-aware-functions/
- https://datatracker.ietf.org/doc/rfc9514/
- https://datatracker.ietf.org/doc/rfc9552/
- https://datatracker.ietf.org/doc/draft-ietf-idr-bgp-ls-sr-service-segments/
- https://www.iana.org/assignments/bgp-ls-parameters/bgp-ls-parameters.xhtml